### PR TITLE
Update check_battery and setup file

### DIFF
--- a/.config/qtile/autostart.sh
+++ b/.config/qtile/autostart.sh
@@ -3,7 +3,7 @@ feh --bg-scale /usr/share/endeavouros/backgrounds/endeavouros-wallpaper.png
 picom & disown # --experimental-backends --vsync should prevent screen tearing on most setups if needed
 
 # Low battery notifier
-~/.config/qtile/scripts/low_bat_notifier.sh & disown
+~/.config/qtile/scripts/check_battery.sh & disown
 
 # Start welcome
 eos-welcome & disown

--- a/.config/qtile/config.py
+++ b/.config/qtile/config.py
@@ -229,7 +229,7 @@ screens = [
                        fontsize = 28,
                        foreground='#2f343f'
                        ),    
-                #widget.Battery(battery=1, discharge_char='    ', low_percentage=0.25, charge_char='    ' , foreground='5bc236', format='{char} {percent:2.0%}', update_interval=30),
+                widget.Battery(battery=1, discharge_char='    ', low_percentage=0.25, charge_char='    ' , foreground='5bc236', format='{char} {percent:2.0%}', update_interval=30),
                 widget.Clock(format=' %Y-%m-%d %a %I:%M %p',
                              background="#2f343f",
                              foreground='#9bd689'),

--- a/.config/qtile/scripts/check_battery.sh
+++ b/.config/qtile/scripts/check_battery.sh
@@ -1,24 +1,30 @@
 #!/bin/sh
 
-low_bat_notifier.sh
+#start notifier script
+~/.config/qtile/scripts/low_bat_notifier.sh
 
+#low battery level, you can modify it
+low_bat=26
+
+#Do not modify these variables
 charging="fully-charged"
 not_charging="discharging"
-bat_now=$(cat /sys/class/power_supply/BAT1/capacity)
-low_bat=30
+bat_now=$(cat /sys/class/power_supply/BAT0/capacity)
+check=2
 
 #I check if the battery is not charging, the script is not running and the battery
-#perchantage is higher than low battery. Because otherwise is the perchantage < low_battery
-#then we would spam notification to the end user
+#perchantage is higher than low battery or if the battery was charging before.
+#In this way the user can receive notification each time the battery level is low
+#without spamming notifications
 
 while true
 do
 	check_running=$(pgrep -fl low_battery.sh)
-	state=$(upower -i /org/freedesktop/UPower/devices/battery_BAT1 | grep state | awk '{print $2}')
-
+	state=$(upower -i /org/freedesktop/UPower/devices/battery_BAT0 | grep state | awk '{print $2}')
 	if [ "$state" = "$charged" ]; then
-		sleep 300
-	elif [ "$state" = "$not_charging" ] && [ -z "$check_running" ] && [ "$bat_now" -gt "$low_bat" ];then
-		low_bat_notifier.sh
+		check=1
+		sleep 30
+	elif [ "$state" = "$not_charging" ] && [ -z "$check_running" ] && ( [ "$bat_now" -gt "$low_bat" ]  || [ "$check" -lt 2 ] );then
+		~/.config/qtile/scripts/low_bat.sh
 	fi
 done

--- a/setup.sh
+++ b/setup.sh
@@ -15,8 +15,23 @@ then
   cp -r .config/gtk-3.0 ~/.config/
   rm -rf ~/.config/qtile/
   cp -r .config/qtile ~/.config/
+  check_chassis
   rm -rf ~/.config/rofi/
   cp -r .config/rofi ~/.config/
+  rm -rf ~/.config/dunst
+  cp -r .config/dunst ~/.config
+  #Just make the files executable by git update-index --chmod=+x low_bat_notifier.sh and then commit to the repo
   chmod +x ~/.config/qtile/scripts/low_bat_notifier.sh
   echo 'done'
 fi
+
+check_chassis(){
+	line="widget.Battery(battery=1, discharge_char='    ', low_percentage=0.25, charge_char='   ', foreground='5bc236', format='{char} {percent:2.0%}', update_interval=30),"
+	commented_line="#"
+	commented_line+=$line
+	chassis_type=$(cat /sys/class/dmi/id/chassis_type)
+	#chassis numbers go from 1 to 11, from 8 to 11 there are all devices with a battery
+	if [ "$chassis_type" -lt 8 ]; then
+  		sed -i "s/$line/$commented_line/" ~/.config/qtile/config.py
+	fi
+}


### PR DESCRIPTION
So, as you can see in the setup file I added the copy of dunst, but also I added the function to check if the device has a battery, if it doesn't, it will comment out the widget.Battery line. (So please make sure the bar will look good weather with or without the widget).

Also In the check_battery file, now I check if in the current xorg session the user already used his battery charger, so in case the battery charger doesn't work or it will disconnect when the battery is still low, it will send notifications anyway. Also I modified the line of autostart, because now battery_notifier will be called directly by the check_battery script. 