### PR TITLE
Bugfix

### DIFF
--- a/.config/qtile/modules/groups.py
+++ b/.config/qtile/modules/groups.py
@@ -1,5 +1,5 @@
 from libqtile.config import Key, Group
-from libqtile.lazy import lazy
+from libqtile.command import lazy
 from .keys import keys, mod
 
 groups = [Group(i) for i in "123456789"]


### PR DESCRIPTION
`lazy` should be imported using `libqtile.command` not `libqtile.lazy`. The latter creates a lookup loop.