### PR TITLE
Bugfix

### DIFF
--- a/.config/qtile/modules/screens.py
+++ b/.config/qtile/modules/screens.py
@@ -1,6 +1,7 @@
 from libqtile import bar
 from .widgets import *
 from libqtile.config import Screen
+from modules.keys import terminal
 import os
 
 screens = [


### PR DESCRIPTION
The variable `terminal` was undefined unless you pulled it in from `keys.py`.