### PR TITLE
Add single quote to fix broken fonts in gtk apps

### DIFF
--- a/.config/gtk-3.0/settings.ini
+++ b/.config/gtk-3.0/settings.ini
@@ -1,7 +1,7 @@
 [Settings]
 gtk-theme-name=Arc-Dark
 gtk-icon-theme-name=Papirus-Dark
-gtk-font-name=Cascadia Code 12
+gtk-font-name='Cascadia Code 12'
 gtk-cursor-theme-name=Neutral
 gtk-cursor-theme-size=0
 gtk-toolbar-style=GTK_TOOLBAR_BOTH_HORIZ


### PR DESCRIPTION

This simple pull should fix broken font that I've recently been experiencing with Qtile.