### PR TITLE
Move `mod+Right` and `mod+Left` keybindings out of `for` loop

### DIFF
--- a/.config/qtile/modules/groups.py
+++ b/.config/qtile/modules/groups.py
@@ -15,7 +15,11 @@ groups = [
 ]
 
 keys.extend([
-    Key([mod], "grave", lazy.group["dropdown"].dropdown_toggle("terminal"))
+    Key([mod], "grave", lazy.group["dropdown"].dropdown_toggle("terminal")),
+    Key([mod], "Right", lazy.screen.next_group(),
+        desc="Switch to next group"),
+    Key([mod], "Left", lazy.screen.prev_group(),
+        desc="Switch to previous group"),
 ])
 
 for i in groups:
@@ -25,12 +29,6 @@ for i in groups:
             i.name,
             lazy.group[i.name].toscreen(),
             desc="Switch to group {}".format(i.name)),
-
-        Key([mod], "Right", lazy.screen.next_group(),
-            desc="Switch to next group"),
-
-        Key([mod], "Left", lazy.screen.prev_group(),
-            desc="Switch to previous group"),
 
         # mod1 + shift + letter of group = switch to & move focused window to group
         Key([mod, "shift"],


### PR DESCRIPTION
The current config generates the keyboard shortcuts for 

- `lazy.screen.next_group()` (<kbd>mod</kbd>+<kbd>Right</kbd>) and
- `lazy.screen.prev_group()` (<kbd>mod</kbd>+<kbd>Left</kbd>)

inside of the `for i in groups` loop. As these keyboard shortcuts don't depend on the currently selected group, this creates `len(groups) - 1` redundant entries in the `keys` list.

This PR moves these two keyboard shortcuts outside of the loop.