### PR TITLE
replace deprecated command.lazy with lazy.lazy

### DIFF
--- a/.config/qtile/modules/groups.py
+++ b/.config/qtile/modules/groups.py
@@ -1,5 +1,5 @@
 from libqtile.config import Scratchpad, DropDown, Key, Group
-from libqtile.command import lazy
+from libqtile.lazy import lazy
 from .keys import keys, mod
 
 groups = [


### PR DESCRIPTION
without this change, this config will not load on qtile versions 0.26.0 or newer

https://github.com/qtile/qtile/blob/master/CHANGELOG for reference