### PR TITLE
Rofi rewrite

### DIFF
--- a/.config/qtile/config.py
+++ b/.config/qtile/config.py
@@ -28,7 +28,7 @@ keys = [
     Key([mod], "k", lazy.layout.up(), desc="Move focus up"),
     Key([mod], "space", lazy.layout.next(), desc="Move window focus to other window"),
     # Rofi
-    Key([mod], "r", lazy.spawn("rofi -show combi"), desc="spawn rofi"),
+    Key([mod], "r", lazy.spawn("rofi -show drun"), desc="spawn rofi"),
     # Move windows between left/right columns or move up/down in current stack.
     # Moving out of range in Columns layout will create new column.
     Key(
@@ -228,7 +228,7 @@ screens = [
                     margin=3,
                     background="#2f343f",
                     mouse_callbacks={
-                        "Button1": lambda: qtile.cmd_spawn("rofi -show combi")
+                        "Button1": lambda: qtile.cmd_spawn("rofi -show drun")
                     },
                 ),
                 widget.Sep(padding=5, linewidth=0, background="#2f343f"),

--- a/.config/rofi/powermenu.sh
+++ b/.config/rofi/powermenu.sh
@@ -1,11 +1,11 @@
 #!/bin/env bash
 
 # Options for powermenu
-lock="    Lock"
-logout="󰗼    Logout"
-shutdown="    Shutdown"
-reboot="󰁯    Reboot"
-sleep="   Sleep"
+lock=$'\tLock'
+logout=$'󰍃\tLogout'
+sleep=$'\tSleep'
+reboot=$'\tReboot'
+shutdown=$'󰐥\tShutdown'
 
 # Get answer from user via rofi
 selected_option=$(echo "$lock


### PR DESCRIPTION
1. Fix icons + visual enhancement:
![ksnip_20240728-130323](https://github.com/user-attachments/assets/c5674c22-68f4-4866-88e7-0141b8365969)

2. In the original config `combi` mode is used for rofi. `combi` mode combines all commands + all windows. This could be overwhelming for the user because every single command is displayed and since some of the commands don't have an icon, it becomes aesthetically less pleasant. I change this to `drun`. With `drun` only the apps are displayed.      


Let me know if you have any suggestions! 