### PR TITLE
fix: replace CurrentLayoutIcon with CurrentLayout

### DIFF
--- a/.config/qtile/config.py
+++ b/.config/qtile/config.py
@@ -259,7 +259,7 @@ screens = [
                     fontsize=13,
                     padding=3,
                 ),
-                widget.CurrentLayoutIcon(scale=0.70),
+                widget.CurrentLayout(scale=0.70),
                 widget.Sep(padding=4, linewidth=0),
                 widget.TextBox(
                     text="",


### PR DESCRIPTION
fix CurrentLayoutIcon : 
- The CurrentLayoutIcon widget has been deprecated and its functionality has been merged into the CurrentLayout widget. 